### PR TITLE
Allow PHP 7.3 in composer.json

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,7 +1,7 @@
 {
     "name": "magento/module-tax-sample-data-venia",
     "require": {
-        "php": "~7.1.3||~7.2.0",
+        "php": "~7.1.3||~7.3.0",
         "magento/module-tax": "100.3.*"
     },
     "type": "magento2-module",

--- a/composer.json
+++ b/composer.json
@@ -1,7 +1,7 @@
 {
     "name": "magento/module-tax-sample-data-venia",
     "require": {
-        "php": "~7.1.3||~7.3.0",
+        "php": "~7.1.3|~7.2.0|~7.3.0",
         "magento/module-tax": "100.3.*"
     },
     "type": "magento2-module",


### PR DESCRIPTION
Magento 2.3 is now expected to support PHP 7.3, but we have found in https://github.com/magento/pwa-studio/issues/1550 that the Venia sample data modules won't install in that environment. This line in composer.json may be the culprit, at least for this module.